### PR TITLE
use filename instead of filenameRelative for Babel v7 compat

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -24,7 +24,7 @@ const typesStub = {
 };
 
 const createSourceFile = filename => {
-  return { file: { opts: { filenameRelative: filename } }, opts: {} };
+  return { file: { opts: { filename: filename } }, opts: {} };
 };
 
 it("compiles ok", () => {

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ export const getModuleType = state => {
 
 export const getNewPath = (path, state) => {
   debug("Generating new path");
-  const sourcePath = dirname(state.file.opts.filenameRelative);
+  const sourcePath = dirname(state.file.opts.filename);
   const requirePath = resolve(sourcePath, path);
   const rootPath = requirePath.replace(globalPath, "");
   const newPath = join(globalPath, compileDir, getModuleType(state), rootPath);


### PR DESCRIPTION
I was trying to get this plugin to work with Babel v7 (beta) to test using it with the latest beta (v6 canary) version of NextJS's `with-reasonml` example.  For some reason it seems like the `state` passed to `ImportDeclaration` no longer includes `state.filename.opts.filenameRelative` as it's undefined causing it to fail.  

Changing it to use `state.filename.opts.filename` instead works properly for Babel v6 and v7 (beta) and passes tests.